### PR TITLE
Feature/windows support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This tool can be used to resize iOS and Android application icons in batch. That
 
 The tool itself is a Node.js app/module so you'll need to have Node.js v0.8+ installed.
 
-The image resizing is done with [ImageMagick](http://www.imagemagick.org/). Make sure you have ImageMagick's `convert` command available in the command line.  Windows users, see [Windows](#Windows) section below.
+The image resizing is done with [ImageMagick](http://www.imagemagick.org/). Make sure you have ImageMagick's `convert` command available in the command line.  Windows users, see [Windows Support](#windows-support) section below.
 
 ## Installation
 
@@ -41,38 +41,52 @@ The `resize()` function's `options` argument takes the following optional parame
 * **androidOutputFilename**: The output file name for the Android icons.
 * **androidBaseSize**: The base size, in pixels, to consider for the `baseRatio`calculation. Default: 48.
 * **config**: Optional path to a `.js` or `.json` file that defines the thumbnail size configuration. Default: use the built-in `config.js` file.
-* **convertBin**:  *Windows machines only*.  See [Windows](#Windows) below.  Default `convert`;
+* **convertBin**:  *Windows machines only*.  See [Windows](#windows) below.  Default `convert`.
+
+
 ### Standalone Application
 
 You can run the tool as an application like this:
 
-    mobile-icon-resizer OPTIONS
+```shell
+mobile-icon-resizer OPTIONS
+```
 
 The application can write its usage documentation to the command line. To view it, run:
 
-    mobile-icon-resizer -h
+```shell
+mobile-icon-resizer -h
+```
 
 Example output:
 
-    mobile-icon-resizer OPTIONS
+```shell
+mobile-icon-resizer OPTIONS
+```
 
-    Options:
-      --input, -i        The prefix of the iOS image files.                [default: "appicon_1024.png"]
-      --iosprefix        The prefix of the iOS image files.                            [default: "Icon"]
-      --iosof            The output folder for the iOS icons.                             [default: "."]
-      --androidof        The output folder for the Android icons.                         [default: "."]
-      --androidofn       The output file name for the Android icons.
-      --androidbs        The base size, in pixels, for `baseRatio` sizing calculation.     [default: 48]
-      --platforms        For which platforms should the icons be resized. Comma-separated list.
-                         Possible values: ios, android                          [default: "ios,android"]
-      --config           A file with custom thumbnail sizes configuration.
-      --convertbin       *Windows only*.  See Windows seciton below.            [default:  "convert"]
-      -v, --version      Print the script's version.
-      -h, --help         Display this help text.
+```shell
+Options:
+  --input, -i        The prefix of the iOS image files.                [default: "appicon_1024.png"]
+  --iosprefix        The prefix of the iOS image files.                            [default: "Icon"]
+  --iosof            The output folder for the iOS icons.                             [default: "."]
+  --androidof        The output folder for the Android icons.                         [default: "."]
+  --androidofn       The output file name for the Android icons.
+  --androidbs        The base size, in pixels, for `baseRatio` sizing calculation.     [default: 48]
+  --platforms        For which platforms should the icons be resized. Comma-separated list.
+                     Possible values: ios, android                          [default: "ios,android"]
+  
+  --config           A file with custom thumbnail sizes configuration.
+  --convertbin       Windows only.  See 'Windows Support' in ReadMe File.  	   [default:  "convert"]
+  
+  -v, --version      Print the script's version.
+  -h, --help         Display this help text.
+```
 
 Example execution:
 
-    mobile-icon-resizer -i appicon_1024.png --iosprefix="Icon" --iosof=output/ios --androidof=output/android --config=custom-sizes.js
+```shell
+mobile-icon-resizer -i appicon_1024.png --iosprefix="Icon" --iosof=output/ios --androidof=output/android --config=custom-sizes.js
+```
 
 ## Thumbnail sizes configuration
 
@@ -88,10 +102,12 @@ This is the way to define absolute sizes.
 
 Here's an example to generate the 512x512 app icon that should be submitted to the Play Store:
 
-    {
-      "size": "512x512",
-      "folder" : "WEB"
-    }
+```json
+{
+  "size": "512x512",
+  "folder" : "WEB"
+}
+```
 
 **`baseRatio`**
 
@@ -99,10 +115,12 @@ This is the preferred way to define the target size of the different icons. The 
 
 In the following example we're generating an icon with the size 72x72 (1.5 * 48).
 
-    {
-      "baseRatio" : "1.5",
-      "folder" : "drawable-hdpi"
-    }
+```json
+{
+  "baseRatio" : "1.5",
+  "folder" : "drawable-hdpi"
+}
+```
 
 **`ratio`**
 
@@ -110,17 +128,19 @@ Legacy way of defining the target size based on the original input file's dimens
 
 Given an input image with size 1024x1024, the following example would generate an image with size 256x256.
 
-    {
-      "ratio" : "1/4",
-      "folder" : "drawable-mdpi"
-    }
+```json
+{
+  "ratio" : "1/4",
+  "folder" : "drawable-mdpi"
+}
+```
 
 
 ## Custom sizing
 
 You can optionally define a file with a custom set of thumbnail size settings and use that instead. The file is either a CommonJS JavaScript file or a plain JSON file.
 
-### CommonJS JavaScript file
+### CommonJS Javascript File
 
 Example:
 
@@ -172,7 +192,7 @@ var config = {
 exports = module.exports = config;
 ```
 
-### Plain JSON file
+### Plain JSON File
 
 Example:
 
@@ -201,8 +221,10 @@ Example:
 
 
 
-### Windows
+## Windows Support
 
-Because Windows has a system file named `convert.exe`, many ImageMagick users on Windows rename the ImageMagick version of `convert.exe` to something like `iconvert.exe` ( see [this StackOverflow answer](http://stackoverflow.com/a/28876385/1167442) ).  You will also need to ensure that the directory that holds the ImageMagick binaries is included in your `path` variable.
+Because Windows has a system file named `convert.exe`, many ImageMagick users on Windows rename the ImageMagick version of `convert.exe` to something like `iconvert.exe` ( see [this StackOverflow answer](http://stackoverflow.com/a/28876385/1167442) ).  
 
-In addition, add the following property to your configuration file.  `convertBin`, and set the value to whatever you have renamed the file to, e.g. `iconvert` ( the extension is not necessary ).
+You will also need to ensure that the directory that holds the ImageMagick binaries is included in your `path` variable.
+
+In addition, add the `convertBin` property to your configuration file or pass it as a command line parameter as specified above, and set the value to whatever you have renamed the `convert` binary to, e.g. `iconvert` ( the extension is not necessary ).

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Mobile Icon Resizer 
+# Mobile Icon Resizer
 
 This tool can be used to resize iOS and Android application icons in batch. That is, given a 1024x1024 icon, this tool will generate all necessary icon sizes.
 
@@ -6,7 +6,7 @@ This tool can be used to resize iOS and Android application icons in batch. That
 
 The tool itself is a Node.js app/module so you'll need to have Node.js v0.8+ installed.
 
-The image resizing is done with [ImageMagick](http://www.imagemagick.org/). Make sure you have ImageMagick's `convert` command available in the command line.
+The image resizing is done with [ImageMagick](http://www.imagemagick.org/). Make sure you have ImageMagick's `convert` command available in the command line.  Windows users, see [Windows](#Windows) section below.
 
 ## Installation
 
@@ -41,7 +41,7 @@ The `resize()` function's `options` argument takes the following optional parame
 * **androidOutputFilename**: The output file name for the Android icons.
 * **androidBaseSize**: The base size, in pixels, to consider for the `baseRatio`calculation. Default: 48.
 * **config**: Optional path to a `.js` or `.json` file that defines the thumbnail size configuration. Default: use the built-in `config.js` file.
-
+* **convertBin**:  *Windows machines only*.  See [Windows](#Windows) below.  Default `convert`;
 ### Standalone Application
 
 You can run the tool as an application like this:
@@ -66,6 +66,7 @@ Example output:
       --platforms        For which platforms should the icons be resized. Comma-separated list.
                          Possible values: ios, android                          [default: "ios,android"]
       --config           A file with custom thumbnail sizes configuration.
+      --convertbin       *Windows only*.  See Windows seciton below.            [default:  "convert"]
       -v, --version      Print the script's version.
       -h, --help         Display this help text.
 
@@ -123,75 +124,87 @@ You can optionally define a file with a custom set of thumbnail size settings an
 
 Example:
 
-    var config = {
-      iOS: {
-        "images": [
-          {
-            "size" : "29x29",
-            "idiom" : "iphone",
-            "filename" : "-Small.png", // The filename will be prefixed with the provided iOS filename prefix
-            "scale" : "1x"
-          },
-          {
-            "size" : "29x29",
-            "idiom" : "iphone",
-            "filename" : "-Small@2x.png",
-            "scale" : "2x"
-          },
-          // ...
-          {
-            "size" : "76x76",
-            "idiom" : "ipad",
-            "filename" : "-76@2x.png",
-            "scale" : "2x"
-          }
-        ]
+```javascript
+var config = {
+  iOS: {
+    "images": [
+      {
+        "size" : "29x29",
+        "idiom" : "iphone",
+        "filename" : "-Small.png", // The filename will be prefixed with the provided iOS filename prefix
+        "scale" : "1x"
       },
-      android: {
-        "images" : [
-          {
-            "baseRatio" : "1",
-            "folder" : "drawable-mdpi"
-          },
-          // ...
-          {
-            "baseRatio" : "4",
-            "folder" : "drawable-xxxhdpi"
-          },
-          {
-            "size": "512x512",
-            "folder" : "WEB"
-          }
-        ]
+      {
+        "size" : "29x29",
+        "idiom" : "iphone",
+        "filename" : "-Small@2x.png",
+        "scale" : "2x"
+      },
+      // ...
+      {
+        "size" : "76x76",
+        "idiom" : "ipad",
+        "filename" : "-76@2x.png",
+        "scale" : "2x"
       }
-    };
+    ]
+  },
+  android: {
+    "images" : [
+      {
+        "baseRatio" : "1",
+        "folder" : "drawable-mdpi"
+      },
+      // ...
+      {
+        "baseRatio" : "4",
+        "folder" : "drawable-xxxhdpi"
+      },
+      {
+        "size": "512x512",
+        "folder" : "WEB"
+      }
+    ]
+  }
+};
 
-    // Don't forget to export the config object!
-    exports = module.exports = config;
+// Don't forget to export the config object!
+exports = module.exports = config;
+```
 
 ### Plain JSON file
 
 Example:
 
-    {
-      "iOS": {
-        "images": [
-          {
-            "size" : "29x29",
-            "idiom" : "iphone",
-            "filename" : "-Small.png", // The filename will be prefixed with the provided iOS filename prefix
-            "scale" : "1x"
-          },
-          // ...
-        ]
+```json
+{
+  "iOS": {
+    "images": [
+      {
+        "size" : "29x29",
+        "idiom" : "iphone",
+        "filename" : "-Small.png", // The filename will be prefixed with the provided iOS filename prefix
+        "scale" : "1x"
       },
-      "android": {
-        "images" : [
-          {
-            "baseRatio" : "1",
-            "folder" : "drawable-mdpi"
-          },
-          // ...
-        ]
-      }
-    }
+      // ...
+    ]
+  },
+  "android": {
+    "images" : [
+      {
+        "baseRatio" : "1",
+        "folder" : "drawable-mdpi"
+      },
+      // ...
+    ]
+  }
+}
+```
+
+
+
+### Windows
+
+Because Windows has a system file named `convert.exe`, many ImageMagick users on Windows rename the ImageMagick version of `convert.exe` to something like `iconvert.exe` ( see [this StackOverflow answer](http://stackoverflow.com/a/28876385/1167442) ).  You will also need to ensure that the directory that holds the ImageMagick binaries is included in your `path` variable.
+
+In addition, add the following property to your configuration file.  `convertBin`, and set the value to whatever you have renamed the file to, e.g. `iconvert` ( the extension is not necessary ).

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ Example:
       {
         "size" : "29x29",
         "idiom" : "iphone",
-        "filename" : "-Small.png", // The filename will be prefixed with the provided iOS filename prefix
+        "filename" : "-Small.png",
         "scale" : "1x"
       },
       // ...

--- a/README.md
+++ b/README.md
@@ -186,7 +186,6 @@ Example:
         "filename" : "-Small.png",
         "scale" : "1x"
       },
-      // ...
     ]
   },
   "android": {
@@ -195,7 +194,6 @@ Example:
         "baseRatio" : "1",
         "folder" : "drawable-mdpi"
       },
-      // ...
     ]
   }
 }

--- a/config.js
+++ b/config.js
@@ -1,140 +1,114 @@
 var config = {
   iOS: {
-    "images": [
-      {
-        "size" : "29x29",
-        "idiom" : "iphone",
-        "filename" : "-Small.png",
-        "scale" : "1x"
-      },
-      {
-        "size" : "29x29",
-        "idiom" : "iphone",
-        "filename" : "-Small@2x.png",
-        "scale" : "2x"
-      },
-      {
-        "size" : "40x40",
-        "idiom" : "iphone",
-        "filename" : "-40@2x.png",
-        "scale" : "2x"
-      },
-      {
-        "size" : "57x57",
-        "idiom" : "iphone",
-        "filename" : ".png",
-        "scale" : "1x"
-      },
-      {
-        "size" : "57x57",
-        "idiom" : "iphone",
-        "filename" : "@2x.png",
-        "scale" : "2x"
-      },
-      {
-        "size" : "60x60",
-        "idiom" : "iphone",
-        "filename" : "-60@2x.png",
-        "scale" : "2x"
-      },
-      {
-        "size" : "29x29",
-        "idiom" : "ipad",
-        "filename" : "-Small-1.png",
-        "scale" : "1x"
-      },
-      {
-        "size" : "29x29",
-        "idiom" : "ipad",
-        "filename" : "-Small@2x-1.png",
-        "scale" : "2x"
-      },
-      {
-        "size" : "40x40",
-        "idiom" : "ipad",
-        "filename" : "-40.png",
-        "scale" : "1x"
-      },
-      {
-        "size" : "40x40",
-        "idiom" : "ipad",
-        "filename" : "-40@2x-1.png",
-        "scale" : "2x"
-      },
-      {
-        "size" : "50x50",
-        "idiom" : "ipad",
-        "filename" : "-Small-50.png",
-        "scale" : "1x"
-      },
-      {
-        "size" : "50x50",
-        "idiom" : "ipad",
-        "filename" : "-Small-50@2x.png",
-        "scale" : "2x"
-      },
-      {
-        "size" : "72x72",
-        "idiom" : "ipad",
-        "filename" : "-72.png",
-        "scale" : "1x"
-      },
-      {
-        "size" : "72x72",
-        "idiom" : "ipad",
-        "filename" : "-72@2x.png",
-        "scale" : "2x"
-      },
-      {
-        "size" : "76x76",
-        "idiom" : "ipad",
-        "filename" : "-76.png",
-        "scale" : "1x"
-      },
-      {
-        "size" : "76x76",
-        "idiom" : "ipad",
-        "filename" : "-76@2x.png",
-        "scale" : "2x"
-      }
-    ]
+    "images": [{
+      "size": "29x29",
+      "idiom": "iphone",
+      "filename": "-Small.png",
+      "scale": "1x"
+    }, {
+      "size": "29x29",
+      "idiom": "iphone",
+      "filename": "-Small@2x.png",
+      "scale": "2x"
+    }, {
+      "size": "40x40",
+      "idiom": "iphone",
+      "filename": "-40@2x.png",
+      "scale": "2x"
+    }, {
+      "size": "57x57",
+      "idiom": "iphone",
+      "filename": ".png",
+      "scale": "1x"
+    }, {
+      "size": "57x57",
+      "idiom": "iphone",
+      "filename": "@2x.png",
+      "scale": "2x"
+    }, {
+      "size": "60x60",
+      "idiom": "iphone",
+      "filename": "-60@2x.png",
+      "scale": "2x"
+    }, {
+      "size": "29x29",
+      "idiom": "ipad",
+      "filename": "-Small-1.png",
+      "scale": "1x"
+    }, {
+      "size": "29x29",
+      "idiom": "ipad",
+      "filename": "-Small@2x-1.png",
+      "scale": "2x"
+    }, {
+      "size": "40x40",
+      "idiom": "ipad",
+      "filename": "-40.png",
+      "scale": "1x"
+    }, {
+      "size": "40x40",
+      "idiom": "ipad",
+      "filename": "-40@2x-1.png",
+      "scale": "2x"
+    }, {
+      "size": "50x50",
+      "idiom": "ipad",
+      "filename": "-Small-50.png",
+      "scale": "1x"
+    }, {
+      "size": "50x50",
+      "idiom": "ipad",
+      "filename": "-Small-50@2x.png",
+      "scale": "2x"
+    }, {
+      "size": "72x72",
+      "idiom": "ipad",
+      "filename": "-72.png",
+      "scale": "1x"
+    }, {
+      "size": "72x72",
+      "idiom": "ipad",
+      "filename": "-72@2x.png",
+      "scale": "2x"
+    }, {
+      "size": "76x76",
+      "idiom": "ipad",
+      "filename": "-76.png",
+      "scale": "1x"
+    }, {
+      "size": "76x76",
+      "idiom": "ipad",
+      "filename": "-76@2x.png",
+      "scale": "2x"
+    }]
   },
   android: {
-    "images" : [
-      {
-        "baseRatio" : "3/4",
-        "folder" : "drawable-ldpi"
-      },
-      {
-        "baseRatio" : "1",
-        "folder" : "drawable-mdpi"
-      },
-      {
-        "baseRatio" : "4/3",
-        "folder" : "drawable-tvdpi"
-      },
-      {
-        "baseRatio" : "1.5",
-        "folder" : "drawable-hdpi"
-      },
-      {
-        "baseRatio" : "2",
-        "folder" : "drawable-xhdpi"
-      },
-      {
-        "baseRatio" : "3",
-        "folder" : "drawable-xxhdpi"
-      },
-      {
-        "baseRatio" : "4",
-        "folder" : "drawable-xxxhdpi"
-      },
-      {
-        // Image to upload to the Play Store
-        "size": "512x512",
-        "folder" : "WEB"
-      }
-    ]
+    "images": [{
+      "baseRatio": "3/4",
+      "folder": "drawable-ldpi"
+    }, {
+      "baseRatio": "1",
+      "folder": "drawable-mdpi"
+    }, {
+      "baseRatio": "4/3",
+      "folder": "drawable-tvdpi"
+    }, {
+      "baseRatio": "1.5",
+      "folder": "drawable-hdpi"
+    }, {
+      "baseRatio": "2",
+      "folder": "drawable-xhdpi"
+    }, {
+      "baseRatio": "3",
+      "folder": "drawable-xxhdpi"
+    }, {
+      "baseRatio": "4",
+      "folder": "drawable-xxxhdpi"
+    }, {
+      // Image to upload to the Play Store
+      "size": "512x512",
+      "folder": "WEB"
+    }]
   }
 };
 

--- a/lib/resize.js
+++ b/lib/resize.js
@@ -11,7 +11,8 @@ var defaults = {
   IOS_FILE_NAME_PREFIX: 'Icon',
   IOS_OUTPUT_FOLDER: '.',
   ANDROID_OUTPUT_FOLDER: '.',
-  ANDROID_BASE_SIZE: 48
+  ANDROID_BASE_SIZE: 48,
+  CONVERT_BIN: 'convert'
 };
 
 // Convert "29x29" to 29 or "2x" to 2
@@ -35,10 +36,10 @@ function getSizeFromRatio(options) {
 
 function executeResize(options, callback) {
   var dimensions = options.size + 'x' + options.size;
-  var command = 'convert "' + options.inputFile + '" -thumbnail ' + dimensions + ' "' + options.outputFile + '"';
+  var command = options.convertBin + ' "' + options.inputFile + '" -thumbnail ' + dimensions + ' "' + options.outputFile + '"';
 
   child = exec(command,
-    function (err, stdout, stderr) {
+    function(err, stdout, stderr) {
       if (stderr) {
         console.log('stderr: ' + stderr);
       }
@@ -46,7 +47,7 @@ function executeResize(options, callback) {
         console.log('exec error: ' + err);
       }
       callback(err);
-  });
+    });
 }
 
 function convertiOS(options, callback) {
@@ -59,13 +60,13 @@ function convertiOS(options, callback) {
     var baseFolder = options.iosOutputFolder;
     mkdirp.sync(baseFolder);
     var fileName = path.join(baseFolder, options.iosFilenamePrefix + image.filename);
-    executeResize(
-      {
+    executeResize({
+        convertBin: options.convertBin,
         inputFile: options.originalIconFilename,
         size: finalSize,
         outputFile: fileName
       },
-      function (err) {
+      function(err) {
         done(err);
       }
     );
@@ -74,7 +75,7 @@ function convertiOS(options, callback) {
   async.each(
     images,
     handleImage,
-    function (err) {
+    function(err) {
       callback(err);
     }
   );
@@ -93,9 +94,15 @@ function convertAndroid(options, callback) {
   function handleImage(image, done) {
     var size = 100;
     if (image.baseRatio) {
-      size = getSizeFromRatio({ size: options.androidBaseSize, ratio: image.baseRatio});
+      size = getSizeFromRatio({
+        size: options.androidBaseSize,
+        ratio: image.baseRatio
+      });
     } else if (image.ratio) {
-      size = getSizeFromRatio({ size: options.originalSize, ratio: image.ratio});
+      size = getSizeFromRatio({
+        size: options.originalSize,
+        ratio: image.ratio
+      });
     } else if (image.size) {
       size = getSize(image.size);
     } else {
@@ -105,13 +112,13 @@ function convertAndroid(options, callback) {
     var baseFolder = path.join(options.androidOutputFolder, image.folder);
     mkdirp.sync(baseFolder);
     var fileName = path.join(baseFolder, options.androidOutputFilename);
-    executeResize(
-      {
+    executeResize({
+        convertBin: options.convertBin,
         inputFile: options.originalIconFilename,
         size: size,
         outputFile: fileName
       },
-      function (err) {
+      function(err) {
         done(err);
       }
     );
@@ -120,7 +127,7 @@ function convertAndroid(options, callback) {
   async.each(
     images,
     handleImage,
-    function (err) {
+    function(err) {
       callback(err);
     }
   );
@@ -144,7 +151,7 @@ var platformConverters = {
  *                          - androidBaseSize: The base size to consider for the `baseRatio` calculation.
  * @return {[type]}         [description]
  */
-var resize = function (options, callback) {
+var resize = function(options, callback) {
   options = options || {};
 
   options.platformsToBuild = options.platformsToBuild || defaults.PLATFORMS_TO_BUILD;
@@ -154,18 +161,20 @@ var resize = function (options, callback) {
   options.androidOutputFolder = options.androidOutputFolder || defaults.ANDROID_OUTPUT_FOLDER;
   options.androidOutputFilename = options.androidOutputFilename || path.basename(options.originalIconFilename);
   options.androidBaseSize = options.androidBaseSize || defaults.ANDROID_BASE_SIZE;
-
   var dimensions = sizeOf(options.originalIconFilename);
   options.originalSize = Math.max(dimensions.width, dimensions.height);
 
   // Load the actual config object from a custom file or our default config
   options.config = (options.config) ? require(path.resolve(options.config)) : require('../config');
 
+  // command line convertBin ? config file convertBin ? default.
+  options.convertBin = options.convertBin || options.config.convertBin ? options.config.convertBin : defaults.CONVERT_BIN;
+
   async.each(
     options.platformsToBuild,
-    function (item, done) {
+    function(item, done) {
       if (typeof platformConverters[item] !== 'function') {
-        return done(new Error('Platform type "'+item+'" is not supported.'));
+        return done(new Error('Platform type "' + item + '" is not supported.'));
       }
       platformConverters[item](options, done);
     },

--- a/resize.js
+++ b/resize.js
@@ -6,43 +6,47 @@ var resize = require('./lib/resize');
 var VERSION = require('./package.json').version;
 
 var optimist = require('optimist')
-    .wrap(100)
-    .usage('$0 OPTIONS')
-    .options('input', {
-      describe: 'The prefix of the iOS image files.',
-      alias: 'i',
-      default: resize.defaults.ORIGINAL_ICON_FILE_NAME
-    })
-    .options('iosprefix', {
-      describe: 'The prefix of the iOS image files.',
-      default: resize.defaults.IOS_FILE_NAME_PREFIX
-    })
-    .options('iosof', {
-      describe: 'The output folder for the iOS icons.',
-      default: resize.defaults.IOS_OUTPUT_FOLDER
-    })
-    .options('androidof', {
-      describe: 'The output folder for the Android icons.',
-      default: resize.defaults.ANDROID_OUTPUT_FOLDER
-    })
-    .options('androidofn', {
-      describe: 'The output file name for the Android icons.'
-    })
-    .options('androidbs', {
-      describe: 'The base size, in pixels, for `baseRatio` sizing calculation.',
-      default: resize.defaults.ANDROID_BASE_SIZE
-    })
-    .options('platforms', {
-      describe: 'For which platforms should the icons be resized. Comma-separated list.\nPossible values: ' + resize.defaults.PLATFORMS_TO_BUILD.join(', '),
-      default: resize.defaults.PLATFORMS_TO_BUILD.join(',')
-    })
-    .options('config', {
-      describe: 'A file with custom thumbnail sizes configuration.'
-    })
-    .describe('v', 'Print the script\'s version.')
-    .alias('v', 'version')
-    .describe('h', 'Display this help text.')
-    .alias('h', 'help');
+  .wrap(100)
+  .usage('$0 OPTIONS')
+  .options('input', {
+    describe: 'The prefix of the iOS image files.',
+    alias: 'i',
+    default: resize.defaults.ORIGINAL_ICON_FILE_NAME
+  })
+  .options('iosprefix', {
+    describe: 'The prefix of the iOS image files.',
+    default: resize.defaults.IOS_FILE_NAME_PREFIX
+  })
+  .options('iosof', {
+    describe: 'The output folder for the iOS icons.',
+    default: resize.defaults.IOS_OUTPUT_FOLDER
+  })
+  .options('androidof', {
+    describe: 'The output folder for the Android icons.',
+    default: resize.defaults.ANDROID_OUTPUT_FOLDER
+  })
+  .options('androidofn', {
+    describe: 'The output file name for the Android icons.'
+  })
+  .options('androidbs', {
+    describe: 'The base size, in pixels, for `baseRatio` sizing calculation.',
+    default: resize.defaults.ANDROID_BASE_SIZE
+  })
+  .options('platforms', {
+    describe: 'For which platforms should the icons be resized. Comma-separated list.\nPossible values: ' + resize.defaults.PLATFORMS_TO_BUILD.join(', '),
+    default: resize.defaults.PLATFORMS_TO_BUILD.join(',')
+  })
+  .options('config', {
+    describe: 'A file with custom thumbnail sizes configuration.'
+  })
+  .options('convertbin', {
+    describe: 'The file name of your ImageMagick convert executable. (See ReadMe for details)',
+    default: resize.defaults.CONVERT_BIN
+  })
+  .describe('v', 'Print the script\'s version.')
+  .alias('v', 'version')
+  .describe('h', 'Display this help text.')
+  .alias('h', 'help');
 
 var argv = optimist.argv;
 if (argv.help) {
@@ -91,7 +95,11 @@ if (argv.config) {
   options.config = argv.config;
 }
 
-resize(options, function (err) {
+if (argv.convertbin) {
+  options.convertBin = argv.convertbin;
+}
+
+resize(options, function(err) {
   if (err) {
     console.log('Error performing resizing: ' + err);
   }


### PR DESCRIPTION
As it stands, this won't work on Windows because of issues with the ImageMagick `convert` binary.  This request adds a parameter to support a common workaround on Windows systems.

Also, added syntax highlighting to code blocks, and fixed some formatting in the ReadMe file.